### PR TITLE
Amends bucket name to fix NoSuchBucket error

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -12,7 +12,7 @@ amazon:
   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
   region: ap-southeast-2
-  bucket: whisky-library-<%= Rails.env %>
+  bucket: whisky-library
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS


### PR DESCRIPTION
Heroku throwing Aws::S3::Errors::NoSuchBucket error. Unable to make post with image storage.

This PR amends the bucket name to fix NoSuchBucket error